### PR TITLE
fix: Fix notification create 400 bad req

### DIFF
--- a/signals_client.go
+++ b/signals_client.go
@@ -45,7 +45,7 @@ func NewSignalsClient(apiKey string, opts ...ClientOption) *SignalsClient {
 }
 
 type Notification struct {
-	Id                 string              `json:"id"`
+	Id                 string              `json:"id,omitempty"`
 	Name               string              `json:"name"`
 	Description        string              `json:"description,omitempty"`
 	NotificationType   NotificationType    `json:"notificationType"`


### PR DESCRIPTION
```
DEBU[2023-03-27T21:50:23+08:00] error: service.create-spend-limit: failed to create spend limit: API error: response 400 Bad Request: 400 – {"error":"Validation error: `id` field must not be set"} 
```

The ID will be added in create request, then the amberflo server returns 400 for the request.