### PR TITLE
fix: Webhook notification cannot be shown in amberflo UI

### DIFF
--- a/signals_client.go
+++ b/signals_client.go
@@ -54,7 +54,7 @@ type Notification struct {
 	ThresholdValue     string              `json:"thresholdValue"`
 	Range              AggregationInterval `json:"range,omitempty"`
 	Cron               string              `json:"cron,omitempty"`
-	Email              []string            `json:"email,omitempty"`
+	Email              []string            `json:"email"`
 	WebhookUrl         string              `json:"webhookUrl,omitempty"`
 	WebhookHeaders     string              `json:"webhookHeaders,omitempty"`
 	WebhookPayload     string              `json:"webhookPayload,omitempty"`


### PR DESCRIPTION
The amberflow UI https://ui.amberflo.io/alerts/{ID} assumes that the email field always exists. The value should be `[]` if the mode is webhook.

Or it will return an error in the browser:

```
vendor.js:128 TypeError: Cannot read properties of undefined (reading 'length')
```

The email field is missing, then could not run `length`