### PR TITLE
update applied promo structs

### DIFF
--- a/amberflo_http_client.go
+++ b/amberflo_http_client.go
@@ -29,7 +29,7 @@ func NewAmberfloHttpClient(apiKey string, logger Logger, httpClient http.Client)
 	return client
 }
 
-//http client to make REST call
+// http client to make REST call
 func (client *AmberfloHttpClient) sendHttpRequest(apiName string, url string, httpMethod string, payload []byte) ([]byte, error) {
 	signature := fmt.Sprintf("sendHttpRequest(%s, %s, %s): ", apiName, httpMethod, url)
 

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,4 @@
+github.com/google/go-cmp v0.5.2 h1:X2ev0eStA3AbceY54o37/0PQ/UWqKEiiO2dKL5OPaFM=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
 github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=

--- a/invoice_client.go
+++ b/invoice_client.go
@@ -86,7 +86,7 @@ type CreditUnit struct {
 	ShortName       string  `json:"shortName"`
 	Name            string  `json:"name"`
 	Description     string  `json:"description"`
-	ratioToCurrency float64 `json:"ratioToCurrency"`
+	RatioToCurrency float64 `json:"ratioToCurrency"`
 }
 
 type CustomerProductInvoice struct {

--- a/invoice_client.go
+++ b/invoice_client.go
@@ -114,18 +114,18 @@ type CustomerProductInvoice struct {
 }
 
 type GetCustomerInvoiceRequest struct {
-	CustomerId         string `json:"customerId" url:"customerId"`
-	ProductId          string `json:"productId" url:"productId"`
-	FromCache          bool   `json:"fromCache" url:"fromCache"`
-	WithPaymentStatus  bool   `json:"withPaymentStatus" url:"withPaymentStatus"`
+	CustomerId        string `json:"customerId" url:"customerId"`
+	ProductId         string `json:"productId" url:"productId"`
+	FromCache         bool   `json:"fromCache" url:"fromCache"`
+	WithPaymentStatus bool   `json:"withPaymentStatus" url:"withPaymentStatus"`
 }
 
 type GetCustomerInvoiceByDateRequest struct {
 	GetCustomerInvoiceRequest
-	ProductPlanId      string `json:"productPlanId" url:"productPlanId"`
-	Year               int64  `json:"year" url:"year"`
-	Month              int64  `json:"month" url:"month"`
-	Day                int64  `json:"day" url:"day"`
+	ProductPlanId string `json:"productPlanId" url:"productPlanId"`
+	Year          int64  `json:"year" url:"year"`
+	Month         int64  `json:"month" url:"month"`
+	Day           int64  `json:"day" url:"day"`
 }
 
 func NewInvoiceClient(apiKey string, opts ...ClientOption) *InvoiceClient {
@@ -141,21 +141,21 @@ func (ic *InvoiceClient) GetLatestInvoice(getCustomerInvoiceRequest *GetCustomer
 		getCustomerInvoiceRequest.ProductId = "1"
 	}
 	if getCustomerInvoiceRequest.CustomerId == "" {
-		return nil, errors.New("'CustomerId' is a required field");
+		return nil, errors.New("'CustomerId' is a required field")
 	}
 
 	queryParams, err := ic.getQueryParams(getCustomerInvoiceRequest)
 	if err != nil {
 		return nil, err
 	}
-	queryParams = "latest=true&" + queryParams;
+	queryParams = "latest=true&" + queryParams
 
 	body, err := ic.sendGetRequest("", queryParams, signature)
 	if err != nil {
 		return nil, err
 	}
 
-	var customerProductInvoice *CustomerProductInvoice;
+	var customerProductInvoice *CustomerProductInvoice
 	err = json.Unmarshal(body, &customerProductInvoice)
 	if err != nil {
 		return nil, fmt.Errorf("%s Error reading JSON body: %s", signature, err)
@@ -170,11 +170,11 @@ func (ic *InvoiceClient) GetInvoice(getCustomerInvoiceByDateRequest *GetCustomer
 		getCustomerInvoiceByDateRequest.ProductId = "1"
 	}
 	if getCustomerInvoiceByDateRequest.CustomerId == "" ||
-			getCustomerInvoiceByDateRequest.ProductPlanId == "" ||
-			getCustomerInvoiceByDateRequest.Year <= 0 ||
-			getCustomerInvoiceByDateRequest.Month <= 0 ||
-			getCustomerInvoiceByDateRequest.Day <= 0 {
-		return nil, errors.New("'ProductPlanId', 'Year', 'Month' and 'Day' are required fields");
+		getCustomerInvoiceByDateRequest.ProductPlanId == "" ||
+		getCustomerInvoiceByDateRequest.Year <= 0 ||
+		getCustomerInvoiceByDateRequest.Month <= 0 ||
+		getCustomerInvoiceByDateRequest.Day <= 0 {
+		return nil, errors.New("'ProductPlanId', 'Year', 'Month' and 'Day' are required fields")
 	}
 
 	queryParams, err := ic.getQueryParams(getCustomerInvoiceByDateRequest)
@@ -187,7 +187,7 @@ func (ic *InvoiceClient) GetInvoice(getCustomerInvoiceByDateRequest *GetCustomer
 		return nil, err
 	}
 
-	var customerProductInvoice *CustomerProductInvoice;
+	var customerProductInvoice *CustomerProductInvoice
 	err = json.Unmarshal(body, &customerProductInvoice)
 	if err != nil {
 		return nil, fmt.Errorf("%s Error reading JSON body: %s", signature, err)
@@ -202,7 +202,7 @@ func (ic *InvoiceClient) ListInvoice(getCustomerInvoiceRequest *GetCustomerInvoi
 		getCustomerInvoiceRequest.ProductId = "1"
 	}
 	if getCustomerInvoiceRequest.CustomerId == "" {
-		return nil, errors.New("'CustomerId' is a required field");
+		return nil, errors.New("'CustomerId' is a required field")
 	}
 
 	queryParams, err := ic.getQueryParams(getCustomerInvoiceRequest)
@@ -215,7 +215,7 @@ func (ic *InvoiceClient) ListInvoice(getCustomerInvoiceRequest *GetCustomerInvoi
 		return nil, err
 	}
 
-	var customerProductInvoice *[]CustomerProductInvoice;
+	var customerProductInvoice *[]CustomerProductInvoice
 	err = json.Unmarshal(body, &customerProductInvoice)
 	if err != nil {
 		return nil, fmt.Errorf("%s Error reading JSON body: %s", signature, err)

--- a/metering.go
+++ b/metering.go
@@ -37,7 +37,7 @@ type Message struct {
 	SentAt    string `json:"-"`
 }
 
-//Metering message
+// Metering message
 type MeterMessage struct {
 	UniqueId          string            `json:"uniqueId"`
 	MeterApiName      string            `json:"meterApiName"`
@@ -104,7 +104,7 @@ type Metering struct {
 	counter int
 }
 
-//Create a new instance with a custom logger
+// Create a new instance with a custom logger
 func NewMeteringClient(apiKey string, opts ...MeteringOption) *Metering {
 	m := &Metering{
 		Endpoint:        IngestEndpoint,
@@ -138,7 +138,7 @@ func NewMeteringClient(apiKey string, opts ...MeteringOption) *Metering {
 	return m
 }
 
-//Queue a metering message to send to Ingest API. Messages are flushes periodically at IntervalSeconds or when the BatchSize limit is exceeded.
+// Queue a metering message to send to Ingest API. Messages are flushes periodically at IntervalSeconds or when the BatchSize limit is exceeded.
 func (m *Metering) Meter(msg *MeterMessage) error {
 	if msg.MeterApiName == "" {
 		return errors.New("'MeterName' is required field")
@@ -155,12 +155,12 @@ func (m *Metering) Meter(msg *MeterMessage) error {
 	return nil
 }
 
-//Start goroutine for concurrent execution to monitor channels
+// Start goroutine for concurrent execution to monitor channels
 func (m *Metering) startLoop() {
 	go m.loop()
 }
 
-//Queue the metering message
+// Queue the metering message
 func (m *Metering) queue(msg message) {
 	m.once.Do(m.startLoop)
 	msg.setMessageId(m.uid())
@@ -169,7 +169,7 @@ func (m *Metering) queue(msg message) {
 	m.msgs <- msg
 }
 
-//Flush all messages in the queue, stop the timer, close all channels, shutdown the client
+// Flush all messages in the queue, stop the timer, close all channels, shutdown the client
 func (m *Metering) Shutdown() error {
 	m.log("Running shutdown....")
 	m.once.Do(m.startLoop)
@@ -183,7 +183,7 @@ func (m *Metering) Shutdown() error {
 	return nil
 }
 
-//Sends batch to API asynchonrously and limits the number of concurrrent calls to API
+// Sends batch to API asynchonrously and limits the number of concurrrent calls to API
 func (m *Metering) sendAsync(msgs []interface{}) {
 	m.mutex.Lock()
 
@@ -211,7 +211,7 @@ func (m *Metering) sendAsync(msgs []interface{}) {
 	}()
 }
 
-//Send the batch request with retry
+// Send the batch request with retry
 func (m *Metering) send(msgs []interface{}) error {
 	if len(msgs) == 0 {
 		return nil
@@ -250,7 +250,7 @@ func backoffDelay(retryNumber int) time.Duration {
 	return time.Duration(duration * rand.Float64() * oneSecond)
 }
 
-//Ingest Api Client code
+// Ingest Api Client code
 func (m *Metering) ingestToApi(b []byte) error {
 	m.logf("Ingest API Payload %s", string(b))
 	url := m.Endpoint + "/ingest"
@@ -263,7 +263,7 @@ func (m *Metering) ingestToApi(b []byte) error {
 	return nil
 }
 
-//Run the listener loop in a separate thread to monitor all channels
+// Run the listener loop in a separate thread to monitor all channels
 func (m *Metering) loop() {
 	var msgs []interface{}
 	tick := time.NewTicker(m.IntervalSeconds)

--- a/promotions_client.go
+++ b/promotions_client.go
@@ -31,16 +31,16 @@ type CustomerAppliedPromotion struct {
 }
 
 type EntityProductInvoice struct {
-    InvoiceUri           string  `json:"invoiceUri"`
-    CreatedTimeInSeconds int64   `json:"createdTimeInSeconds"`
-    Amount               float64 `json:"amount"`
-    InvoiceAmount        float64 `json:"invoiceAmount"`
+	InvoiceUri           string  `json:"invoiceUri"`
+	CreatedTimeInSeconds int64   `json:"createdTimeInSeconds"`
+	Amount               float64 `json:"amount"`
+	InvoiceAmount        float64 `json:"invoiceAmount"`
 }
 
 type ApplyPromotionRequest struct {
-	CustomerId  string `json:"customerId"`
-	PromotionId string `json:"promotionId"`
-	ProductId   string `json:"productId"`
+	CustomerId       string     `json:"customerId"`
+	PromotionId      string     `json:"promotionId"`
+	ProductId        string     `json:"productId"`
 	AppliedTimeRange *TimeRange `json:"appliedTimeRange,omitempty"`
 }
 

--- a/promotions_client.go
+++ b/promotions_client.go
@@ -16,11 +16,13 @@ func NewPromotionClient(apiKey string, opts ...ClientOption) *PromotionClient {
 	return pc
 }
 
+// Deprecated: AppliedTimeInSeconds is deprecated.
 type CustomerAppliedPromotion struct {
 	CustomerId            string                 `json:"customerId"`
 	PromotionId           string                 `json:"promotionId"`
 	ProductId             string                 `json:"productId"`
 	AppliedTimeInSeconds  int64                  `json:"appliedTimeInSeconds"`
+	AppliedTimeRange      *TimeRange             `json:"appliedTimeRange"`
 	AddedTimeInSeconds    int64                  `json:"addedTimeInSeconds"`
 	RemovedTimeInSeconds  int64                  `json:"removedTimeInSeconds"`
 	RelationId            string                 `json:"relationId"`

--- a/promotions_client.go
+++ b/promotions_client.go
@@ -41,6 +41,7 @@ type ApplyPromotionRequest struct {
 	CustomerId  string `json:"customerId"`
 	PromotionId string `json:"promotionId"`
 	ProductId   string `json:"productId"`
+	AppliedTimeRange *TimeRange `json:"appliedTimeRange,omitempty"`
 }
 
 type RemovePromotionRequest struct {


### PR DESCRIPTION
### Context
Firebolt has requested the ability to apply promotions with a given start time

### Main changes
[promotions_client.go](https://github.com/amberflo/metering-go/compare/joe/update-applied-promo-input?expand=1#diff-f8369b02bb194dd99565e63fcd8e9f8f078783233bbecdd9b8447ead60459314) - Adding the appliedTimeRange field to both input/output structs

[invoice_client.go](https://github.com/amberflo/metering-go/compare/joe/update-applied-promo-input?expand=1#diff-af86b794d91187852b3e85978c130ca919622c4649a73946b5f0b507caa7694f) - Just fixing the capitalization of RatioToCurrency field

### Testing
Verified by running an integration test locally in staging
