### PR TITLE
Add prepaid price fields to invoice

### DIFF
--- a/invoice_client.go
+++ b/invoice_client.go
@@ -107,6 +107,8 @@ type CustomerProductInvoice struct {
 	PaymentCreatedInSeconds           int64                           `json:"paymentCreatedInSeconds"`
 	ExternalSystemStatus              string                          `json:"externalSystemStatus"`
 	InvoiceBillInCredits              ProductPlanBill                 `json:"invoiceBillInCredits"`
+	PrepaidPriceUsedBaseCurrency      float64                         `json:"prepaidPriceUsedBaseCurrency"`
+	PrepaidPriceUsed                  float64                         `json:"prepaidPriceUsed"`
 	AvailablePrepaidLeft              float64                         `json:"availablePrepaidLeft"`
 	AvailablePrepaidLeftInCredits     float64                         `json:"availablePrepaidLeftInCredits"`
 	AvailablePayAsYouGoMoney          float64                         `json:"availablePayAsYouGoMoney"`


### PR DESCRIPTION
Context
https://aflo.atlassian.net/browse/CSR-426

Problem
The prepaid price fields are available in the API but not through SDK

Main changes
invoice_client.go: add prepaid price fields

Testing
Verified by using invoice client to get invoice locally and confirming that the prepaid price fields have values
<img width="361" alt="image" src="https://github.com/user-attachments/assets/4692a478-b2a1-4950-a9ab-5e0fa787d38a">