### PR TITLE
Add address to customer

### DIFF
--- a/customer_client.go
+++ b/customer_client.go
@@ -19,15 +19,24 @@ type CustomerClient struct {
 	BaseClient
 }
 
+type Address struct {
+	Line1      string `json:"line1"`
+	State      string `json:"state"`
+	City       string `json:"city"`
+	PostalCode string `json:"postalCode"`
+	Country    string `json:"country"`
+}
+
 type Customer struct {
-	CustomerId     string            `json:"customerId"`
-	CustomerName   string            `json:"customerName"`
-	CustomerEmail  string            `json:"customerEmail"`
-	Traits         map[string]string `json:"traits,omitempty"`
-	LifecycleStage LifecycleStage    `json:"lifecycleStage,omitempty"`
-	Enabled        bool              `json:"enabled"`
-	UpdateTime     int64             `json:"updateTime,omitempty"`
-	CreateTime     int64             `json:"createTime,omitempty"`
+	CustomerId      string            `json:"customerId"`
+	CustomerName    string            `json:"customerName"`
+	CustomerEmail   string            `json:"customerEmail"`
+	Traits          map[string]string `json:"traits,omitempty"`
+	CustomerAddress Address           `json:"address"`
+	LifecycleStage  LifecycleStage    `json:"lifecycleStage,omitempty"`
+	Enabled         bool              `json:"enabled"`
+	UpdateTime      int64             `json:"updateTime,omitempty"`
+	CreateTime      int64             `json:"createTime,omitempty"`
 }
 
 type UpdateLifecycleStageRequest struct {


### PR DESCRIPTION
### Problem
Customer address field available through API but not through SDK
https://aflo.atlassian.net/browse/CSR-477

### Main Changes
customer_client.go: added customer address field

### Testing
Confirmed that the customer object has address object when fetching customer (with the correct values)
<img width="233" alt="image" src="https://github.com/user-attachments/assets/cbc05a2b-4abf-45fc-8ca8-3d1d3a7aa577" />
