### PR TITLE
make address in customer optional

### DIFF
--- a/customer_client.go
+++ b/customer_client.go
@@ -32,7 +32,7 @@ type Customer struct {
 	CustomerName    string            `json:"customerName"`
 	CustomerEmail   string            `json:"customerEmail"`
 	Traits          map[string]string `json:"traits,omitempty"`
-	CustomerAddress Address           `json:"address"`
+	CustomerAddress Address           `json:"address,omitempty"`
 	LifecycleStage  LifecycleStage    `json:"lifecycleStage,omitempty"`
 	Enabled         bool              `json:"enabled"`
 	UpdateTime      int64             `json:"updateTime,omitempty"`


### PR DESCRIPTION
### Context

Previous PR added `address` field to customer object but it wasn't made optional. 