### PR TITLE
use reference for customer address

### DIFF
--- a/customer_client.go
+++ b/customer_client.go
@@ -32,7 +32,7 @@ type Customer struct {
 	CustomerName    string            `json:"customerName"`
 	CustomerEmail   string            `json:"customerEmail"`
 	Traits          map[string]string `json:"traits,omitempty"`
-	CustomerAddress Address           `json:"address,omitempty"`
+	CustomerAddress *Address          `json:"address,omitempty"`
 	LifecycleStage  LifecycleStage    `json:"lifecycleStage,omitempty"`
 	Enabled         bool              `json:"enabled"`
 	UpdateTime      int64             `json:"updateTime,omitempty"`


### PR DESCRIPTION
### Context
Previously added address field and omitempty for that field. However since the field was not a reference type, the omitempty was not working properly
https://aflo.atlassian.net/browse/CSR-484

### Testing
Confirmed that address not returned for customers without address
![image](https://github.com/user-attachments/assets/829cf10b-9747-4b4f-96bb-a945e8cf5483)

Confirmed that address is included and correct for customers with address
![image](https://github.com/user-attachments/assets/439939f5-ee50-45fe-956c-0c07d5977daf)
